### PR TITLE
Fix CRUD fields for all resources

### DIFF
--- a/saas-admin/README.md
+++ b/saas-admin/README.md
@@ -17,7 +17,7 @@ VITE_AUTH_STORAGE_KEY=saas_admin_token
 VITE_TENANT_HEADER_NAME=x-tenant-id
 ```
 
-## Installation & Run
+## Setup
 
 ```bash
 npm ci
@@ -26,8 +26,8 @@ npm run dev
 
 ## Adding Resources
 
-Create a folder under `src/resources/<name>` with `list.tsx`, `create.tsx`, `edit.tsx`, and `show.tsx`, then export them via `index.ts` and register in `App.tsx`.
+Create a folder under `src/resources/<name>` with `list.tsx`, `create.tsx`, `edit.tsx`, and `show.tsx` files. Export them via an `index.ts` file and register the resource in `App.tsx`.
 
 ## Tenant Selector
 
-`TenantSelector` in the top bar loads sites and sets the tenant header for site-bound resources automatically.
+`TenantSelector` in the top bar fetches the available sites and stores the selected site via `setTenantSite`. The data provider then attaches the tenant header for resources that are site-bound.

--- a/saas-admin/src/resources/features/create.tsx
+++ b/saas-admin/src/resources/features/create.tsx
@@ -1,9 +1,18 @@
-import { Create, SimpleForm, TextInput, required } from 'react-admin';
+import {
+  Create,
+  SimpleForm,
+  TextInput,
+  BooleanInput,
+  required
+} from 'react-admin';
 
 export const FeatureCreate = () => (
   <Create>
     <SimpleForm>
+      <TextInput source="code" validate={required()} />
       <TextInput source="name" validate={required()} />
+      <TextInput source="description" />
+      <BooleanInput source="isActive" />
     </SimpleForm>
   </Create>
 );

--- a/saas-admin/src/resources/features/edit.tsx
+++ b/saas-admin/src/resources/features/edit.tsx
@@ -1,9 +1,18 @@
-import { Edit, SimpleForm, TextInput, required } from 'react-admin';
+import {
+  Edit,
+  SimpleForm,
+  TextInput,
+  BooleanInput,
+  required
+} from 'react-admin';
 
 export const FeatureEdit = () => (
   <Edit>
     <SimpleForm>
+      <TextInput source="code" validate={required()} />
       <TextInput source="name" validate={required()} />
+      <TextInput source="description" />
+      <BooleanInput source="isActive" />
     </SimpleForm>
   </Edit>
 );

--- a/saas-admin/src/resources/features/list.tsx
+++ b/saas-admin/src/resources/features/list.tsx
@@ -1,12 +1,23 @@
-import { List, Datagrid, TextField, DateField, TextInput, TopToolbar, CreateButton } from 'react-admin';
+import {
+  List,
+  Datagrid,
+  TextField,
+  BooleanField,
+  DateField,
+  TextInput,
+  TopToolbar,
+  CreateButton
+} from 'react-admin';
 
-const filters = [<TextInput source="name" label="Name" alwaysOn />];
+const filters = [<TextInput source="code" label="Code" alwaysOn />];
 
 export const FeatureList = () => (
   <List filters={filters} actions={<TopToolbar><CreateButton /></TopToolbar>}>
     <Datagrid rowClick="show">
       <TextField source="id" />
+      <TextField source="code" />
       <TextField source="name" />
+      <BooleanField source="isActive" />
       <DateField source="createdAt" />
     </Datagrid>
   </List>

--- a/saas-admin/src/resources/features/show.tsx
+++ b/saas-admin/src/resources/features/show.tsx
@@ -1,10 +1,19 @@
-import { Show, SimpleShowLayout, TextField, DateField } from 'react-admin';
+import {
+  Show,
+  SimpleShowLayout,
+  TextField,
+  BooleanField,
+  DateField
+} from 'react-admin';
 
 export const FeatureShow = () => (
   <Show>
     <SimpleShowLayout>
       <TextField source="id" />
+      <TextField source="code" />
       <TextField source="name" />
+      <TextField source="description" />
+      <BooleanField source="isActive" />
       <DateField source="createdAt" />
       <DateField source="updatedAt" />
     </SimpleShowLayout>

--- a/saas-admin/src/resources/payments/create.tsx
+++ b/saas-admin/src/resources/payments/create.tsx
@@ -1,9 +1,29 @@
-import { Create, SimpleForm, TextInput, required } from 'react-admin';
+import {
+  Create,
+  SimpleForm,
+  NumberInput,
+  TextInput,
+  SelectInput,
+  required
+} from 'react-admin';
 
 export const PaymentCreate = () => (
   <Create>
     <SimpleForm>
-      <TextInput source="name" validate={required()} />
+      <NumberInput source="amountCents" validate={required()} />
+      <TextInput source="currency" defaultValue="USD" />
+      <SelectInput
+        source="status"
+        choices={[
+          { id: 'pending', name: 'pending' },
+          { id: 'paid', name: 'paid' },
+          { id: 'failed', name: 'failed' },
+          { id: 'refunded', name: 'refunded' }
+        ]}
+        defaultValue="pending"
+      />
+      <TextInput source="externalId" />
+      <TextInput source="invoiceNo" />
     </SimpleForm>
   </Create>
 );

--- a/saas-admin/src/resources/payments/edit.tsx
+++ b/saas-admin/src/resources/payments/edit.tsx
@@ -1,9 +1,28 @@
-import { Edit, SimpleForm, TextInput, required } from 'react-admin';
+import {
+  Edit,
+  SimpleForm,
+  NumberInput,
+  TextInput,
+  SelectInput,
+  required
+} from 'react-admin';
 
 export const PaymentEdit = () => (
   <Edit>
     <SimpleForm>
-      <TextInput source="name" validate={required()} />
+      <NumberInput source="amountCents" validate={required()} />
+      <TextInput source="currency" defaultValue="USD" />
+      <SelectInput
+        source="status"
+        choices={[
+          { id: 'pending', name: 'pending' },
+          { id: 'paid', name: 'paid' },
+          { id: 'failed', name: 'failed' },
+          { id: 'refunded', name: 'refunded' }
+        ]}
+      />
+      <TextInput source="externalId" />
+      <TextInput source="invoiceNo" />
     </SimpleForm>
   </Edit>
 );

--- a/saas-admin/src/resources/payments/list.tsx
+++ b/saas-admin/src/resources/payments/list.tsx
@@ -1,12 +1,22 @@
-import { List, Datagrid, TextField, DateField, TextInput, TopToolbar, CreateButton } from 'react-admin';
+import {
+  List,
+  Datagrid,
+  TextField,
+  DateField,
+  TextInput,
+  TopToolbar,
+  CreateButton
+} from 'react-admin';
 
-const filters = [<TextInput source="name" label="Name" alwaysOn />];
+const filters = [<TextInput source="externalId" label="External ID" alwaysOn />];
 
 export const PaymentList = () => (
   <List filters={filters} actions={<TopToolbar><CreateButton /></TopToolbar>}>
     <Datagrid rowClick="show">
       <TextField source="id" />
-      <TextField source="name" />
+      <TextField source="amountCents" />
+      <TextField source="currency" />
+      <TextField source="status" />
       <DateField source="createdAt" />
     </Datagrid>
   </List>

--- a/saas-admin/src/resources/payments/show.tsx
+++ b/saas-admin/src/resources/payments/show.tsx
@@ -4,7 +4,11 @@ export const PaymentShow = () => (
   <Show>
     <SimpleShowLayout>
       <TextField source="id" />
-      <TextField source="name" />
+      <TextField source="amountCents" />
+      <TextField source="currency" />
+      <TextField source="status" />
+      <TextField source="externalId" />
+      <TextField source="invoiceNo" />
       <DateField source="createdAt" />
       <DateField source="updatedAt" />
     </SimpleShowLayout>

--- a/saas-admin/src/resources/planFeatures/create.tsx
+++ b/saas-admin/src/resources/planFeatures/create.tsx
@@ -1,9 +1,20 @@
-import { Create, SimpleForm, TextInput, required } from 'react-admin';
+import {
+  Create,
+  SimpleForm,
+  ReferenceInput,
+  SelectInput,
+  required
+} from 'react-admin';
 
 export const PlanFeatureCreate = () => (
   <Create>
     <SimpleForm>
-      <TextInput source="name" validate={required()} />
+      <ReferenceInput source="planId" reference="plans" validate={required()}>
+        <SelectInput optionText="name" />
+      </ReferenceInput>
+      <ReferenceInput source="featureId" reference="features" validate={required()}>
+        <SelectInput optionText="name" />
+      </ReferenceInput>
     </SimpleForm>
   </Create>
 );

--- a/saas-admin/src/resources/planFeatures/edit.tsx
+++ b/saas-admin/src/resources/planFeatures/edit.tsx
@@ -1,9 +1,20 @@
-import { Edit, SimpleForm, TextInput, required } from 'react-admin';
+import {
+  Edit,
+  SimpleForm,
+  ReferenceInput,
+  SelectInput,
+  required
+} from 'react-admin';
 
 export const PlanFeatureEdit = () => (
   <Edit>
     <SimpleForm>
-      <TextInput source="name" validate={required()} />
+      <ReferenceInput source="planId" reference="plans" validate={required()}>
+        <SelectInput optionText="name" />
+      </ReferenceInput>
+      <ReferenceInput source="featureId" reference="features" validate={required()}>
+        <SelectInput optionText="name" />
+      </ReferenceInput>
     </SimpleForm>
   </Edit>
 );

--- a/saas-admin/src/resources/planFeatures/list.tsx
+++ b/saas-admin/src/resources/planFeatures/list.tsx
@@ -1,12 +1,22 @@
-import { List, Datagrid, TextField, DateField, TextInput, TopToolbar, CreateButton } from 'react-admin';
+import {
+  List,
+  Datagrid,
+  TextField,
+  DateField,
+  TopToolbar,
+  CreateButton,
+  ReferenceField,
+  TextInput
+} from 'react-admin';
 
-const filters = [<TextInput source="name" label="Name" alwaysOn />];
+const filters = [<TextInput source="planId" label="Plan" alwaysOn />];
 
 export const PlanFeatureList = () => (
   <List filters={filters} actions={<TopToolbar><CreateButton /></TopToolbar>}>
     <Datagrid rowClick="show">
       <TextField source="id" />
-      <TextField source="name" />
+      <ReferenceField source="planId" reference="plans" />
+      <ReferenceField source="featureId" reference="features" />
       <DateField source="createdAt" />
     </Datagrid>
   </List>

--- a/saas-admin/src/resources/planFeatures/show.tsx
+++ b/saas-admin/src/resources/planFeatures/show.tsx
@@ -1,10 +1,17 @@
-import { Show, SimpleShowLayout, TextField, DateField } from 'react-admin';
+import {
+  Show,
+  SimpleShowLayout,
+  TextField,
+  ReferenceField,
+  DateField
+} from 'react-admin';
 
 export const PlanFeatureShow = () => (
   <Show>
     <SimpleShowLayout>
       <TextField source="id" />
-      <TextField source="name" />
+      <ReferenceField source="planId" reference="plans" />
+      <ReferenceField source="featureId" reference="features" />
       <DateField source="createdAt" />
       <DateField source="updatedAt" />
     </SimpleShowLayout>

--- a/saas-admin/src/resources/plans/create.tsx
+++ b/saas-admin/src/resources/plans/create.tsx
@@ -1,9 +1,20 @@
-import { Create, SimpleForm, TextInput, required } from 'react-admin';
+import {
+  Create,
+  SimpleForm,
+  TextInput,
+  NumberInput,
+  BooleanInput,
+  required
+} from 'react-admin';
 
 export const PlanCreate = () => (
   <Create>
     <SimpleForm>
+      <TextInput source="code" validate={required()} />
       <TextInput source="name" validate={required()} />
+      <NumberInput source="priceCents" />
+      <TextInput source="currency" defaultValue="USD" />
+      <BooleanInput source="isActive" />
     </SimpleForm>
   </Create>
 );

--- a/saas-admin/src/resources/plans/edit.tsx
+++ b/saas-admin/src/resources/plans/edit.tsx
@@ -1,9 +1,20 @@
-import { Edit, SimpleForm, TextInput, required } from 'react-admin';
+import {
+  Edit,
+  SimpleForm,
+  TextInput,
+  NumberInput,
+  BooleanInput,
+  required
+} from 'react-admin';
 
 export const PlanEdit = () => (
   <Edit>
     <SimpleForm>
+      <TextInput source="code" validate={required()} />
       <TextInput source="name" validate={required()} />
+      <NumberInput source="priceCents" />
+      <TextInput source="currency" />
+      <BooleanInput source="isActive" />
     </SimpleForm>
   </Edit>
 );

--- a/saas-admin/src/resources/plans/list.tsx
+++ b/saas-admin/src/resources/plans/list.tsx
@@ -1,12 +1,25 @@
-import { List, Datagrid, TextField, DateField, TextInput, TopToolbar, CreateButton } from 'react-admin';
+import {
+  List,
+  Datagrid,
+  TextField,
+  BooleanField,
+  DateField,
+  TextInput,
+  TopToolbar,
+  CreateButton
+} from 'react-admin';
 
-const filters = [<TextInput source="name" label="Name" alwaysOn />];
+const filters = [<TextInput source="code" label="Code" alwaysOn />];
 
 export const PlanList = () => (
   <List filters={filters} actions={<TopToolbar><CreateButton /></TopToolbar>}>
     <Datagrid rowClick="show">
       <TextField source="id" />
+      <TextField source="code" />
       <TextField source="name" />
+      <TextField source="priceCents" />
+      <TextField source="currency" />
+      <BooleanField source="isActive" />
       <DateField source="createdAt" />
     </Datagrid>
   </List>

--- a/saas-admin/src/resources/plans/show.tsx
+++ b/saas-admin/src/resources/plans/show.tsx
@@ -1,10 +1,20 @@
-import { Show, SimpleShowLayout, TextField, DateField } from 'react-admin';
+import {
+  Show,
+  SimpleShowLayout,
+  TextField,
+  BooleanField,
+  DateField
+} from 'react-admin';
 
 export const PlanShow = () => (
   <Show>
     <SimpleShowLayout>
       <TextField source="id" />
+      <TextField source="code" />
       <TextField source="name" />
+      <TextField source="priceCents" />
+      <TextField source="currency" />
+      <BooleanField source="isActive" />
       <DateField source="createdAt" />
       <DateField source="updatedAt" />
     </SimpleShowLayout>

--- a/saas-admin/src/resources/siteFeatures/create.tsx
+++ b/saas-admin/src/resources/siteFeatures/create.tsx
@@ -1,9 +1,19 @@
-import { Create, SimpleForm, TextInput, required } from 'react-admin';
+import {
+  Create,
+  SimpleForm,
+  ReferenceInput,
+  SelectInput,
+  BooleanInput,
+  required
+} from 'react-admin';
 
 export const SiteFeatureCreate = () => (
   <Create>
     <SimpleForm>
-      <TextInput source="name" validate={required()} />
+      <ReferenceInput source="featureId" reference="features" validate={required()}>
+        <SelectInput optionText="name" />
+      </ReferenceInput>
+      <BooleanInput source="isActive" />
     </SimpleForm>
   </Create>
 );

--- a/saas-admin/src/resources/siteFeatures/edit.tsx
+++ b/saas-admin/src/resources/siteFeatures/edit.tsx
@@ -1,9 +1,19 @@
-import { Edit, SimpleForm, TextInput, required } from 'react-admin';
+import {
+  Edit,
+  SimpleForm,
+  ReferenceInput,
+  SelectInput,
+  BooleanInput,
+  required
+} from 'react-admin';
 
 export const SiteFeatureEdit = () => (
   <Edit>
     <SimpleForm>
-      <TextInput source="name" validate={required()} />
+      <ReferenceInput source="featureId" reference="features" validate={required()}>
+        <SelectInput optionText="name" />
+      </ReferenceInput>
+      <BooleanInput source="isActive" />
     </SimpleForm>
   </Edit>
 );

--- a/saas-admin/src/resources/siteFeatures/list.tsx
+++ b/saas-admin/src/resources/siteFeatures/list.tsx
@@ -1,12 +1,23 @@
-import { List, Datagrid, TextField, DateField, TextInput, TopToolbar, CreateButton } from 'react-admin';
+import {
+  List,
+  Datagrid,
+  TextField,
+  BooleanField,
+  DateField,
+  TextInput,
+  TopToolbar,
+  CreateButton,
+  ReferenceField
+} from 'react-admin';
 
-const filters = [<TextInput source="name" label="Name" alwaysOn />];
+const filters = [<TextInput source="featureId" label="Feature" alwaysOn />];
 
 export const SiteFeatureList = () => (
   <List filters={filters} actions={<TopToolbar><CreateButton /></TopToolbar>}>
     <Datagrid rowClick="show">
       <TextField source="id" />
-      <TextField source="name" />
+      <ReferenceField source="featureId" reference="features" />
+      <BooleanField source="isActive" />
       <DateField source="createdAt" />
     </Datagrid>
   </List>

--- a/saas-admin/src/resources/siteFeatures/show.tsx
+++ b/saas-admin/src/resources/siteFeatures/show.tsx
@@ -1,10 +1,18 @@
-import { Show, SimpleShowLayout, TextField, DateField } from 'react-admin';
+import {
+  Show,
+  SimpleShowLayout,
+  TextField,
+  BooleanField,
+  DateField,
+  ReferenceField
+} from 'react-admin';
 
 export const SiteFeatureShow = () => (
   <Show>
     <SimpleShowLayout>
       <TextField source="id" />
-      <TextField source="name" />
+      <ReferenceField source="featureId" reference="features" />
+      <BooleanField source="isActive" />
       <DateField source="createdAt" />
       <DateField source="updatedAt" />
     </SimpleShowLayout>

--- a/saas-admin/src/resources/sitePlans/create.tsx
+++ b/saas-admin/src/resources/sitePlans/create.tsx
@@ -1,9 +1,23 @@
-import { Create, SimpleForm, TextInput, required } from 'react-admin';
+import {
+  Create,
+  SimpleForm,
+  ReferenceInput,
+  SelectInput,
+  BooleanInput,
+  DateInput,
+  required
+} from 'react-admin';
 
 export const SitePlanCreate = () => (
   <Create>
     <SimpleForm>
-      <TextInput source="name" validate={required()} />
+      <ReferenceInput source="planId" reference="plans" validate={required()}>
+        <SelectInput optionText="name" />
+      </ReferenceInput>
+      <BooleanInput source="isActive" />
+      <DateInput source="startsAt" />
+      <DateInput source="endsAt" />
+      <TextInput source="status" />
     </SimpleForm>
   </Create>
 );

--- a/saas-admin/src/resources/sitePlans/edit.tsx
+++ b/saas-admin/src/resources/sitePlans/edit.tsx
@@ -1,9 +1,24 @@
-import { Edit, SimpleForm, TextInput, required } from 'react-admin';
+import {
+  Edit,
+  SimpleForm,
+  ReferenceInput,
+  SelectInput,
+  BooleanInput,
+  DateInput,
+  TextInput,
+  required
+} from 'react-admin';
 
 export const SitePlanEdit = () => (
   <Edit>
     <SimpleForm>
-      <TextInput source="name" validate={required()} />
+      <ReferenceInput source="planId" reference="plans" validate={required()}>
+        <SelectInput optionText="name" />
+      </ReferenceInput>
+      <BooleanInput source="isActive" />
+      <DateInput source="startsAt" />
+      <DateInput source="endsAt" />
+      <TextInput source="status" />
     </SimpleForm>
   </Edit>
 );

--- a/saas-admin/src/resources/sitePlans/list.tsx
+++ b/saas-admin/src/resources/sitePlans/list.tsx
@@ -1,13 +1,26 @@
-import { List, Datagrid, TextField, DateField, TextInput, TopToolbar, CreateButton } from 'react-admin';
+import {
+  List,
+  Datagrid,
+  TextField,
+  BooleanField,
+  DateField,
+  TextInput,
+  TopToolbar,
+  CreateButton,
+  ReferenceField
+} from 'react-admin';
 
-const filters = [<TextInput source="name" label="Name" alwaysOn />];
+const filters = [<TextInput source="status" label="Status" alwaysOn />];
 
 export const SitePlanList = () => (
   <List filters={filters} actions={<TopToolbar><CreateButton /></TopToolbar>}>
     <Datagrid rowClick="show">
       <TextField source="id" />
-      <TextField source="name" />
-      <DateField source="createdAt" />
+      <ReferenceField source="planId" reference="plans" />
+      <BooleanField source="isActive" />
+      <DateField source="startsAt" />
+      <DateField source="endsAt" />
+      <TextField source="status" />
     </Datagrid>
   </List>
 );

--- a/saas-admin/src/resources/sitePlans/show.tsx
+++ b/saas-admin/src/resources/sitePlans/show.tsx
@@ -1,10 +1,21 @@
-import { Show, SimpleShowLayout, TextField, DateField } from 'react-admin';
+import {
+  Show,
+  SimpleShowLayout,
+  TextField,
+  BooleanField,
+  DateField,
+  ReferenceField
+} from 'react-admin';
 
 export const SitePlanShow = () => (
   <Show>
     <SimpleShowLayout>
       <TextField source="id" />
-      <TextField source="name" />
+      <ReferenceField source="planId" reference="plans" />
+      <BooleanField source="isActive" />
+      <DateField source="startsAt" />
+      <DateField source="endsAt" />
+      <TextField source="status" />
       <DateField source="createdAt" />
       <DateField source="updatedAt" />
     </SimpleShowLayout>

--- a/saas-admin/src/resources/siteThemes/create.tsx
+++ b/saas-admin/src/resources/siteThemes/create.tsx
@@ -1,9 +1,19 @@
-import { Create, SimpleForm, TextInput, required } from 'react-admin';
+import {
+  Create,
+  SimpleForm,
+  ReferenceInput,
+  SelectInput,
+  BooleanInput,
+  required
+} from 'react-admin';
 
 export const SiteThemeCreate = () => (
   <Create>
     <SimpleForm>
-      <TextInput source="name" validate={required()} />
+      <ReferenceInput source="themeId" reference="themes" validate={required()}>
+        <SelectInput optionText="name" />
+      </ReferenceInput>
+      <BooleanInput source="isActive" />
     </SimpleForm>
   </Create>
 );

--- a/saas-admin/src/resources/siteThemes/edit.tsx
+++ b/saas-admin/src/resources/siteThemes/edit.tsx
@@ -1,9 +1,19 @@
-import { Edit, SimpleForm, TextInput, required } from 'react-admin';
+import {
+  Edit,
+  SimpleForm,
+  ReferenceInput,
+  SelectInput,
+  BooleanInput,
+  required
+} from 'react-admin';
 
 export const SiteThemeEdit = () => (
   <Edit>
     <SimpleForm>
-      <TextInput source="name" validate={required()} />
+      <ReferenceInput source="themeId" reference="themes" validate={required()}>
+        <SelectInput optionText="name" />
+      </ReferenceInput>
+      <BooleanInput source="isActive" />
     </SimpleForm>
   </Edit>
 );

--- a/saas-admin/src/resources/siteThemes/list.tsx
+++ b/saas-admin/src/resources/siteThemes/list.tsx
@@ -1,12 +1,23 @@
-import { List, Datagrid, TextField, DateField, TextInput, TopToolbar, CreateButton } from 'react-admin';
+import {
+  List,
+  Datagrid,
+  TextField,
+  BooleanField,
+  DateField,
+  TextInput,
+  TopToolbar,
+  CreateButton,
+  ReferenceField
+} from 'react-admin';
 
-const filters = [<TextInput source="name" label="Name" alwaysOn />];
+const filters = [<TextInput source="themeId" label="Theme" alwaysOn />];
 
 export const SiteThemeList = () => (
   <List filters={filters} actions={<TopToolbar><CreateButton /></TopToolbar>}>
     <Datagrid rowClick="show">
       <TextField source="id" />
-      <TextField source="name" />
+      <ReferenceField source="themeId" reference="themes" />
+      <BooleanField source="isActive" />
       <DateField source="createdAt" />
     </Datagrid>
   </List>

--- a/saas-admin/src/resources/siteThemes/show.tsx
+++ b/saas-admin/src/resources/siteThemes/show.tsx
@@ -1,10 +1,18 @@
-import { Show, SimpleShowLayout, TextField, DateField } from 'react-admin';
+import {
+  Show,
+  SimpleShowLayout,
+  TextField,
+  BooleanField,
+  DateField,
+  ReferenceField
+} from 'react-admin';
 
 export const SiteThemeShow = () => (
   <Show>
     <SimpleShowLayout>
       <TextField source="id" />
-      <TextField source="name" />
+      <ReferenceField source="themeId" reference="themes" />
+      <BooleanField source="isActive" />
       <DateField source="createdAt" />
       <DateField source="updatedAt" />
     </SimpleShowLayout>

--- a/saas-admin/src/resources/sites/create.tsx
+++ b/saas-admin/src/resources/sites/create.tsx
@@ -1,9 +1,20 @@
-import { Create, SimpleForm, TextInput, required } from 'react-admin';
+import {
+  Create,
+  SimpleForm,
+  TextInput,
+  ReferenceInput,
+  SelectInput,
+  required
+} from 'react-admin';
 
 export const SiteCreate = () => (
   <Create>
     <SimpleForm>
       <TextInput source="name" validate={required()} />
+      <TextInput source="slug" validate={required()} />
+      <ReferenceInput source="ownerId" reference="users" validate={required()}>
+        <SelectInput optionText="email" />
+      </ReferenceInput>
     </SimpleForm>
   </Create>
 );

--- a/saas-admin/src/resources/sites/edit.tsx
+++ b/saas-admin/src/resources/sites/edit.tsx
@@ -1,9 +1,20 @@
-import { Edit, SimpleForm, TextInput, required } from 'react-admin';
+import {
+  Edit,
+  SimpleForm,
+  TextInput,
+  ReferenceInput,
+  SelectInput,
+  required
+} from 'react-admin';
 
 export const SiteEdit = () => (
   <Edit>
     <SimpleForm>
       <TextInput source="name" validate={required()} />
+      <TextInput source="slug" validate={required()} />
+      <ReferenceInput source="ownerId" reference="users" validate={required()}>
+        <SelectInput optionText="email" />
+      </ReferenceInput>
     </SimpleForm>
   </Edit>
 );

--- a/saas-admin/src/resources/sites/list.tsx
+++ b/saas-admin/src/resources/sites/list.tsx
@@ -1,4 +1,13 @@
-import { List, Datagrid, TextField, DateField, TextInput, TopToolbar, CreateButton } from 'react-admin';
+import {
+  List,
+  Datagrid,
+  TextField,
+  DateField,
+  TextInput,
+  TopToolbar,
+  CreateButton,
+  ReferenceField
+} from 'react-admin';
 
 const filters = [<TextInput source="name" label="Name" alwaysOn />];
 
@@ -7,6 +16,8 @@ export const SiteList = () => (
     <Datagrid rowClick="show">
       <TextField source="id" />
       <TextField source="name" />
+      <TextField source="slug" />
+      <ReferenceField source="ownerId" reference="users" link={false} />
       <DateField source="createdAt" />
     </Datagrid>
   </List>

--- a/saas-admin/src/resources/sites/show.tsx
+++ b/saas-admin/src/resources/sites/show.tsx
@@ -1,10 +1,18 @@
-import { Show, SimpleShowLayout, TextField, DateField } from 'react-admin';
+import {
+  Show,
+  SimpleShowLayout,
+  TextField,
+  DateField,
+  ReferenceField
+} from 'react-admin';
 
 export const SiteShow = () => (
   <Show>
     <SimpleShowLayout>
       <TextField source="id" />
       <TextField source="name" />
+      <TextField source="slug" />
+      <ReferenceField source="ownerId" reference="users" />
       <DateField source="createdAt" />
       <DateField source="updatedAt" />
     </SimpleShowLayout>

--- a/saas-admin/src/resources/themes/create.tsx
+++ b/saas-admin/src/resources/themes/create.tsx
@@ -1,9 +1,17 @@
-import { Create, SimpleForm, TextInput, required } from 'react-admin';
+import {
+  Create,
+  SimpleForm,
+  TextInput,
+  BooleanInput,
+  required
+} from 'react-admin';
 
 export const ThemeCreate = () => (
   <Create>
     <SimpleForm>
+      <TextInput source="code" validate={required()} />
       <TextInput source="name" validate={required()} />
+      <BooleanInput source="isActive" />
     </SimpleForm>
   </Create>
 );

--- a/saas-admin/src/resources/themes/edit.tsx
+++ b/saas-admin/src/resources/themes/edit.tsx
@@ -1,9 +1,17 @@
-import { Edit, SimpleForm, TextInput, required } from 'react-admin';
+import {
+  Edit,
+  SimpleForm,
+  TextInput,
+  BooleanInput,
+  required
+} from 'react-admin';
 
 export const ThemeEdit = () => (
   <Edit>
     <SimpleForm>
+      <TextInput source="code" validate={required()} />
       <TextInput source="name" validate={required()} />
+      <BooleanInput source="isActive" />
     </SimpleForm>
   </Edit>
 );

--- a/saas-admin/src/resources/themes/list.tsx
+++ b/saas-admin/src/resources/themes/list.tsx
@@ -1,12 +1,23 @@
-import { List, Datagrid, TextField, DateField, TextInput, TopToolbar, CreateButton } from 'react-admin';
+import {
+  List,
+  Datagrid,
+  TextField,
+  BooleanField,
+  DateField,
+  TextInput,
+  TopToolbar,
+  CreateButton
+} from 'react-admin';
 
-const filters = [<TextInput source="name" label="Name" alwaysOn />];
+const filters = [<TextInput source="code" label="Code" alwaysOn />];
 
 export const ThemeList = () => (
   <List filters={filters} actions={<TopToolbar><CreateButton /></TopToolbar>}>
     <Datagrid rowClick="show">
       <TextField source="id" />
+      <TextField source="code" />
       <TextField source="name" />
+      <BooleanField source="isActive" />
       <DateField source="createdAt" />
     </Datagrid>
   </List>

--- a/saas-admin/src/resources/themes/show.tsx
+++ b/saas-admin/src/resources/themes/show.tsx
@@ -1,10 +1,18 @@
-import { Show, SimpleShowLayout, TextField, DateField } from 'react-admin';
+import {
+  Show,
+  SimpleShowLayout,
+  TextField,
+  BooleanField,
+  DateField
+} from 'react-admin';
 
 export const ThemeShow = () => (
   <Show>
     <SimpleShowLayout>
       <TextField source="id" />
+      <TextField source="code" />
       <TextField source="name" />
+      <BooleanField source="isActive" />
       <DateField source="createdAt" />
       <DateField source="updatedAt" />
     </SimpleShowLayout>


### PR DESCRIPTION
## Summary
- use real schema fields for Payments, SitePlans, SiteFeatures, SiteThemes
- allow selecting plans and features via references in PlanFeatures
- expose code, price and status fields on Plans
- add code/description/isActive fields to Features and Themes
- include slug and owner selection for Sites
- document setup and tenant selector in README

## Testing
- `npm install`
- `npm run dev` *(launches Vite dev server without build errors)*

------
https://chatgpt.com/codex/tasks/task_e_688785b0e13c8322a95ff928d18d0e4a